### PR TITLE
detect any gomod files matching go.*.mod

### DIFF
--- a/ftdetect/gomod.vim
+++ b/ftdetect/gomod.vim
@@ -1,5 +1,5 @@
 au! BufRead,BufNewFile *.mod,*.MOD
-autocmd BufRead,BufNewFile go.mod call s:gomod()
+autocmd BufRead,BufNewFile go.{,*.}mod call s:gomod()
 
 fun! s:gomod()
   for l:i in range(1, line('$'))


### PR DESCRIPTION
Go allows us to configure the gomod file by [`-modfile` flag](https://golang.org/cmd/go/#:~:text=-modfile), and some repos uses this to split the tool dependency ([mattermost-server](https://github.com/mattermost/mattermost-server/blob/v5.31.0/go.tools.mod)). I think it is worth matching `go.*.mod` pattern as well.